### PR TITLE
Remove resolvable address check

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,3 @@ There's a number of boolean options to enforce the presence of parts of a URI to
 * `require_port`: for example, `"https://github.com:433"`
 * `require_user`: for example, `"https://user@github.com"`
 * `require_password`: for example, `"https://:password@github.com"`
-
-#### Verifying resolvable addresses
-
-By default `uri` will make sure that the URI's host is a resolvable public address, meaning that private IPs will fail validation. You can override this behavior with the `allow_private_ip: true` option.

--- a/lib/coercive/uri.rb
+++ b/lib/coercive/uri.rb
@@ -3,27 +3,6 @@ require "uri"
 
 module Coercive
   module URI
-    # The IP ranges below are considered private and by default not permitted by the `uri`
-    # coercion function. To allow connecting to local services (in development, for example)
-    # users can set the `allow_private_ip` option, which ignores if the URI resolves to a public
-    # address or not.
-    PRIVATE_IP_RANGES = [
-      IPAddr.new("0.0.0.0/8"),       # Broadcasting to the current network. RFC 1700.
-      IPAddr.new("10.0.0.0/8"),      # Local private network. RFC 1918.
-      IPAddr.new("127.0.0.0/8"),     # Loopback addresses to the localhost. RFC 990.
-      IPAddr.new("169.254.0.0/16"),  # link-local addresses between two hosts on a single link. RFC 3927.
-      IPAddr.new("172.16.0.0/12"),   # Local private network. RFC 1918.
-      IPAddr.new("192.168.0.0/16"),  # Local private network. RFC 1918.
-      IPAddr.new("198.18.0.0/15"),   # Testing of inter-network communications between two separate subnets. RFC 2544.
-      IPAddr.new("198.51.100.0/24"), # Assigned as "TEST-NET-2" in RFC 5737.
-      IPAddr.new("203.0.113.0/24"),  # Assigned as "TEST-NET-3" in RFC 5737.
-      IPAddr.new("240.0.0.0/4"),     # Reserved for future use, as specified by RFC 6890
-      IPAddr.new("::1/128"),         # Loopback addresses to the localhost. RFC 5156.
-      IPAddr.new("2001:20::/28"),    # Non-routed IPv6 addresses used for Cryptographic Hash Identifiers. RFC 7343.
-      IPAddr.new("fc00::/7"),        # Unique Local Addresses (ULAs). RFC 1918.
-      IPAddr.new("fe80::/10"),       # link-local addresses between two hosts on a single link. RFC 3927.
-    ].freeze
-
     # Public DSL: Return a coercion function to coerce input to a URI.
     # Used when declaring an attribute. See documentation for attr_coerce_fns.
     #
@@ -34,8 +13,7 @@ module Coercive
     # require_user     - set true to make the URI user a required element
     # require_password - set true to make the URI password a required element
     def self.coerce_fn(string_coerce_fn, schema_fn: nil, require_path: false,
-            require_port: false, require_user: false, require_password: false,
-            allow_private_ip: false)
+            require_port: false, require_user: false, require_password: false)
       ->(input) do
         uri = begin
           ::URI.parse(string_coerce_fn.call(input))
@@ -44,7 +22,6 @@ module Coercive
         end
 
         fail Coercive::Error.new("no_host") unless uri.host
-        fail Coercive::Error.new("not_resolvable") unless allow_private_ip || resolvable_public_ip?(uri)
         fail Coercive::Error.new("no_path") if require_path && uri.path.empty?
         fail Coercive::Error.new("no_port") if require_port && !uri.port
         fail Coercive::Error.new("no_user") if require_user && !uri.user
@@ -60,41 +37,6 @@ module Coercive
 
         uri.to_s
       end
-    end
-
-    # Internal: Return true if the given URI is resolvable to a non-private IP.
-    #
-    # uri - the URI to check.
-    def self.resolvable_public_ip?(uri)
-      begin
-        _, _, _, *resolved_addresses = Socket.gethostbyname(uri.host)
-      rescue SocketError
-        return false
-      end
-
-      resolved_addresses.none? do |bytes|
-        ip = ip_from_bytes(bytes)
-
-        ip.nil? || PRIVATE_IP_RANGES.any? { |range| range.include?(ip) }
-      end
-    end
-
-    # Internal: Return an IPAddr built from the given address bytes.
-    #
-    # bytes - the binary-encoded String returned by Socket.gethostbyname.
-    def self.ip_from_bytes(bytes)
-      octets = bytes.unpack("C*")
-
-      string =
-        if octets.length == 4 # IPv4
-          octets.join(".")
-        else # IPv6
-          octets.map { |i| "%02x" % i }.each_slice(2).map(&:join).join(":")
-        end
-
-      IPAddr.new(string)
-    rescue IPAddr::InvalidAddressError
-      nil
     end
   end
 end

--- a/test/uri.rb
+++ b/test/uri.rb
@@ -39,10 +39,6 @@ describe "Coercive::URI" do
       attribute :require_password,
         uri(string(min: 1, max: 255), require_password: true),
         optional
-
-      attribute :allow_private_ip,
-        uri(string(min: 1, max: 255), allow_private_ip: true),
-        optional
     end
   end
 
@@ -127,57 +123,8 @@ describe "Coercive::URI" do
     assert_coercion_error(expected_errors) { @coercion.call(attributes) }
   end
 
-  Coercive::URI::PRIVATE_IP_RANGES.each do |range|
-    range = range.to_range
-    first = range.first
-    last  = range.last
-    first = first.ipv6? ? "[#{first}]" : first.to_s
-    last  = last.ipv6?  ? "[#{last}]"  : last.to_s
-
-    it "errors when the URI host is an IP in the range #{first}..#{last}" do
-      attributes_first = { "schema" => "http://#{first}/path" }
-      attributes_last  = { "schema" => "http://#{last}/path" }
-      expected_errors  = { "schema" => "not_resolvable" }
-
-      assert_coercion_error(expected_errors) { @coercion.call(attributes_first) }
-      assert_coercion_error(expected_errors) { @coercion.call(attributes_last) }
-    end
-
-    it "allows overriding private IP address checks" do
-      attributes_first = { "allow_private_ip" => "http://#{first}/path" }
-      attributes_last  = { "allow_private_ip" => "http://#{last}/path" }
-
-      assert_equal attributes_first, @coercion.call(attributes_first)
-      assert_equal attributes_last,  @coercion.call(attributes_last)
-    end
-  end
-
-  it "errors when the URI host is not resolvable" do
-    attributes = {
-      "schema" => "http://bogus-host-that-cant-possibly-exist-here/path"
-    }
-
-    expected_errors = { "schema" => "not_resolvable" }
-
-    assert_coercion_error(expected_errors) { @coercion.call(attributes) }
-  end
-
-  it "errors when the URI host resolves to an IP in a private range" do
-    attributes = { "schema" => "http://localhost/path" }
-
-    expected_errors = { "schema" => "not_resolvable" }
-
-    assert_coercion_error(expected_errors) { @coercion.call(attributes) }
-  end
-
-  it "allows a URI host to be IP that isn't in a private range" do
+  it "allows a URI host to be an IP" do
     attributes = { "schema" => "http://8.8.8.8/path" }
-
-    assert_equal attributes, @coercion.call(attributes)
-  end
-
-  it "allows a URI host that resolves to an IP not in a private range" do
-    attributes = { "schema" => "http://www.example.com/path" }
 
     assert_equal attributes, @coercion.call(attributes)
   end


### PR DESCRIPTION
In the context of the project where Coercive was designed making sure addresses were resolving properly was a requirement, but it's not something we should impose for the general use.