### PR TITLE
Add format option to date and datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,19 +130,23 @@ CoerceFoo.call("foo" => "DEADBEEF")
 
 ### `date` and `datetime`
 
-The `date` and `datetime` coercion functions will receive an ISO 8601 string and give you `Date` and `DateTime` objects, respectively.
+The `date` and `datetime` coercion functions will receive a `String` and give you `Date` and `DateTime` objects, respectively.
+
+By default they expect an ISO 8601 string, but they provide a `format` option in case you need to parse something different, following the `strftime` format.
 
 ```ruby
 module CoerceFoo
   extend Coercive
 
-  attribute :date_foo,     date,     optional
-  attribute :datetime_foo, datetime, optional
+  attribute :date_foo,      date,                     optional
+  attribute :american_date, date(format: "%m-%d-%Y"), optional
+  attribute :datetime_foo,  datetime,                 optional
 end
 
-CoerceFoo.call("date_foo" => "1988-05-18", "datetime_foo" => "1988-05-18T21:00:00Z")
+CoerceFoo.call("date_foo" => "1988-05-18", "datetime_foo" => "1988-05-18T21:00:00Z", "american_date" => "05-18-1988")
 # => {"date_foo"=>#<Date: 1988-05-18 ((2447300j,0s,0n),+0s,2299161j)>,
-# "datetime_foo"=>#<DateTime: 1988-05-18T21:00:00+00:00 ((2447300j,75600s,0n),+0s,2299161j)>}
+#  "american_date"=>#<Date: 1988-05-18 ((2447300j,0s,0n),+0s,2299161j)>,
+#  "datetime_foo"=>#<DateTime: 1988-05-18T21:00:00+00:00 ((2447300j,75600s,0n),+0s,2299161j)>}
 
 CoerceFoo.call("date_foo" => "18th May 1988")
 # => Coercive::Error: {"date_foo"=>"not_valid"}

--- a/lib/coercive.rb
+++ b/lib/coercive.rb
@@ -193,12 +193,19 @@ module Coercive
     end
   end
 
-  # Public DSL: Return a coercion function to coerce ISO 8601 input into a Date.
+  # Public DSL: Return a coercion function to coerce input into a Date.
   # Used when declaring an attribute. See documentation for attr_coerce_fns.
-  def date
+  #
+  # format - String following Ruby's `strftime` format to change the parsing behavior. When empty
+  #          it will expect the String to be ISO 8601 compatible.
+  def date(format: nil)
     ->(input) do
       input = begin
-                Date.iso8601(input)
+                if format
+                  Date.strptime(input, format)
+                else
+                  Date.iso8601(input)
+                end
               rescue ArgumentError
                 fail Coercive::Error.new("not_valid")
               end
@@ -207,12 +214,19 @@ module Coercive
     end
   end
 
-  # Public DSL: Return a coercion function to coerce ISO 8601 input into a DateTime.
+  # Public DSL: Return a coercion function to coerce input into a DateTime.
   # Used when declaring an attribute. See documentation for attr_coerce_fns.
-  def datetime
+  #
+  # format - String following Ruby's `strftime` format to change the parsing behavior. When empty
+  #          it will expect the String to be ISO 8601 compatible.
+  def datetime(format: nil)
     ->(input) do
       input = begin
-                DateTime.iso8601(input)
+                if format
+                  DateTime.strptime(input, format)
+                else
+                  DateTime.iso8601(input)
+                end
               rescue ArgumentError
                 fail Coercive::Error.new("not_valid")
               end

--- a/test/coercive.rb
+++ b/test/coercive.rb
@@ -204,11 +204,12 @@ describe "Coercive" do
       @coercion = Module.new do
         extend Coercive
 
-        attribute :date, date, required
+        attribute :date,          date,                     optional
+        attribute :american_date, date(format: "%m-%d-%Y"), optional
       end
     end
 
-    it "coerces a string into a Date object" do
+    it "coerces a string into a Date object with ISO 8601 format by default" do
       attributes = { "date" => "1988-05-18" }
 
       expected = { "date" => Date.new(1988, 5, 18) }
@@ -216,8 +217,16 @@ describe "Coercive" do
       assert_equal expected, @coercion.call(attributes)
     end
 
-    it "errors if the input isn't ISO 8601 format" do
-      attributes = { "date" => "18th May 1988" }
+    it "supports a custom date format" do
+      attributes = { "american_date" => "05-18-1988" }
+
+      expected = { "american_date" => Date.new(1988, 5, 18) }
+
+      assert_equal expected, @coercion.call(attributes)
+    end
+
+    it "errors if the input doesn't parse" do
+      attributes = { "date" => "12-31-1990" }
 
       expected_errors = { "date" => "not_valid" }
 
@@ -230,11 +239,12 @@ describe "Coercive" do
       @coercion = Module.new do
         extend Coercive
 
-        attribute :datetime, datetime, required
+        attribute :datetime,      datetime,                                 optional
+        attribute :american_date, datetime(format: "%m-%d-%Y %I:%M:%S %p"), optional
       end
     end
 
-    it "coerces a string into a DateTime object" do
+    it "coerces a string into a DateTime object with ISO 8601 format by default" do
       attributes = { "datetime" => "1988-05-18T21:00:00Z" }
 
       expected = { "datetime" => DateTime.new(1988, 5, 18, 21, 00, 00) }
@@ -250,8 +260,16 @@ describe "Coercive" do
       assert_equal expected, @coercion.call(attributes)
     end
 
-    it "errors if the input isn't ISO 8601 format" do
-      attributes = { "datetime" => "18th May 1988" }
+    it "supports a custom date format" do
+      attributes = { "american_date" => "05-18-1988 09:00:00 PM" }
+
+      expected = { "american_date" => DateTime.new(1988, 5, 18, 21, 00, 00) }
+
+      assert_equal expected, @coercion.call(attributes)
+    end
+
+    it "errors if the input doesn't parse" do
+      attributes = { "datetime" => "12-31-1990T21:00:00Z" }
 
       expected_errors = { "datetime" => "not_valid" }
 


### PR DESCRIPTION
Issue: #2 

The `format` option for the `date` and `datetime` coercion functions is useful if the user needs to apply a different date format than ISO8601.