### PR TITLE
Add integer coercion function

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,12 @@ CoerceFoo.call("foo" => "1")
 
 CoerceFoo.call("foo" => "bar")
 # => Coercive::Error: {"foo"=>"not_valid"}
+
+CoerceFoo.call("foo" => "1.5")
+# => Coercive::Error: {"foo"=>"not_numeric"}
+
+CoerceFoo.call("foo" => 1.5)
+# => Coercive::Error: {"foo"=>"float_not_permitted"}
 ```
 
 ### `float`

--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ CoerceFoo.call("foo" => 4)
 # => Coercive::Error: {"foo"=>"not_valid"}
 ```
 
+### `integer`
+
+`integer` expects an integer value.
+
+```ruby
+module CoerceFoo
+  extend Coercive
+
+  attribute :foo, integer, optional
+end
+
+CoerceFoo.call("foo" => "1")
+# => {"foo"=>1}
+
+CoerceFoo.call("foo" => "bar")
+# => Coercive::Error: {"foo"=>"not_valid"}
+```
+
 ### `float`
 
 `float` expects, well, a float value.

--- a/lib/coercive.rb
+++ b/lib/coercive.rb
@@ -154,6 +154,8 @@ module Coercive
   # Used when declaring an attribute. See documentation for attr_coerce_fns.
   def integer
     ->(input) do
+      fail Coercive::Error.new("float_not_permitted") if input.is_a?(Float)
+
       begin
         Integer(input)
       rescue TypeError, ArgumentError

--- a/lib/coercive.rb
+++ b/lib/coercive.rb
@@ -150,6 +150,18 @@ module Coercive
     end
   end
 
+  # Public DSL: Return a coerce function to coerce input to an Integer.
+  # Used when declaring an attribute. See documentation for attr_coerce_fns.
+  def integer
+    ->(input) do
+      begin
+        Integer(input)
+      rescue TypeError, ArgumentError
+        fail Coercive::Error.new("not_numeric")
+      end
+    end
+  end
+
   # Public DSL: Return a coerce function to coerce input to a Float.
   # Used when declaring an attribute. See documentation for attr_coerce_fns.
   def float

--- a/test/coercive.rb
+++ b/test/coercive.rb
@@ -118,12 +118,18 @@ describe "Coercive" do
       assert_equal expected, @coercion.call(attributes)
     end
 
+    it "doesn't allow Float" do
+      expected_errors = { "foo" => "float_not_permitted" }
+
+      assert_coercion_error(expected_errors) { @coercion.call("foo" => 100.5) }
+    end
+
     it "errors if the input can't be coerced into an Integer" do
-      attributes = { "foo" => "nope" }
+      ["nope", "100.5", "1e5"].each do |value|
+        expected_errors = { "foo" => "not_numeric" }
 
-      expected_errors = { "foo" => "not_numeric" }
-
-      assert_coercion_error(expected_errors) { @coercion.call(attributes) }
+        assert_coercion_error(expected_errors) { @coercion.call("foo" => value) }
+      end
     end
   end
 

--- a/test/coercive.rb
+++ b/test/coercive.rb
@@ -100,6 +100,33 @@ describe "Coercive" do
     end
   end
 
+  describe "integer" do
+    before do
+      @coercion = Module.new do
+        extend Coercive
+
+        attribute :foo, integer, required
+        attribute :bar, integer, optional
+      end
+    end
+
+    it "coerces the input value to an integer" do
+      attributes = { "foo" => "100", "bar" => 100 }
+
+      expected = { "foo" => 100, "bar" => 100 }
+
+      assert_equal expected, @coercion.call(attributes)
+    end
+
+    it "errors if the input can't be coerced into an Integer" do
+      attributes = { "foo" => "nope" }
+
+      expected_errors = { "foo" => "not_numeric" }
+
+      assert_coercion_error(expected_errors) { @coercion.call(attributes) }
+    end
+  end
+
   describe "float" do
     before do
       @coercion = Module.new do


### PR DESCRIPTION
I noticed we had `float` but didn't have `integer`, so I went ahead and added it.