### PR TITLE
Add min and max options to integer coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,10 +196,10 @@ CoerceFoo.call("foo" => 1.5)
 # => Coercive::Error: {"foo"=>"float_not_permitted"}
 
 CoerceFoo.call("foo_bounds" => 0)
-# => Coercive::Error: {"foo_bounds"=>"too_small"}
+# => Coercive::Error: {"foo_bounds"=>"too_low"}
 
 CoerceFoo.call("foo_bounds" => 11)
-# => Coercive::Error: {"foo_bounds"=>"too_large"}
+# => Coercive::Error: {"foo_bounds"=>"too_high"}
 ```
 
 ### `float`

--- a/README.md
+++ b/README.md
@@ -171,15 +171,16 @@ CoerceFoo.call("foo" => 4)
 # => Coercive::Error: {"foo"=>"not_valid"}
 ```
 
-### `integer`
+### `integer(min:, max:)`
 
-`integer` expects an integer value.
+`integer` expects an integer value. It supports optional `min` and `max` options to check if the user input is within certain bounds.
 
 ```ruby
 module CoerceFoo
   extend Coercive
 
-  attribute :foo, integer, optional
+  attribute :foo,        integer,                  optional
+  attribute :foo_bounds, integer(min: 1, max: 10), optional
 end
 
 CoerceFoo.call("foo" => "1")
@@ -193,6 +194,12 @@ CoerceFoo.call("foo" => "1.5")
 
 CoerceFoo.call("foo" => 1.5)
 # => Coercive::Error: {"foo"=>"float_not_permitted"}
+
+CoerceFoo.call("foo_bounds" => 0)
+# => Coercive::Error: {"foo_bounds"=>"too_small"}
+
+CoerceFoo.call("foo_bounds" => 11)
+# => Coercive::Error: {"foo_bounds"=>"too_large"}
 ```
 
 ### `float`

--- a/lib/coercive.rb
+++ b/lib/coercive.rb
@@ -152,15 +152,20 @@ module Coercive
 
   # Public DSL: Return a coerce function to coerce input to an Integer.
   # Used when declaring an attribute. See documentation for attr_coerce_fns.
-  def integer
+  def integer(min: nil, max: nil)
     ->(input) do
       fail Coercive::Error.new("float_not_permitted") if input.is_a?(Float)
 
-      begin
-        Integer(input)
-      rescue TypeError, ArgumentError
-        fail Coercive::Error.new("not_numeric")
-      end
+      input = begin
+                Integer(input)
+              rescue TypeError, ArgumentError
+                fail Coercive::Error.new("not_numeric")
+              end
+
+      fail Coercive::Error.new("too_small") if min && input < min
+      fail Coercive::Error.new("too_large") if max && input > max
+
+      input
     end
   end
 

--- a/lib/coercive.rb
+++ b/lib/coercive.rb
@@ -162,8 +162,8 @@ module Coercive
                 fail Coercive::Error.new("not_numeric")
               end
 
-      fail Coercive::Error.new("too_small") if min && input < min
-      fail Coercive::Error.new("too_large") if max && input > max
+      fail Coercive::Error.new("too_low")  if min && input < min
+      fail Coercive::Error.new("too_high") if max && input > max
 
       input
     end

--- a/test/coercive.rb
+++ b/test/coercive.rb
@@ -134,11 +134,11 @@ describe "Coercive" do
     end
 
     it "errors if the input is out of bounds" do
-      expected_errors = { "baz" => "too_small" }
+      expected_errors = { "baz" => "too_low" }
 
       assert_coercion_error(expected_errors) { @coercion.call("baz" => 0) }
       
-      expected_errors = { "baz" => "too_large" }
+      expected_errors = { "baz" => "too_high" }
 
       assert_coercion_error(expected_errors) { @coercion.call("baz" => 11) }
     end

--- a/test/coercive.rb
+++ b/test/coercive.rb
@@ -105,8 +105,9 @@ describe "Coercive" do
       @coercion = Module.new do
         extend Coercive
 
-        attribute :foo, integer, required
+        attribute :foo, integer, optional
         attribute :bar, integer, optional
+        attribute :baz, integer(min: 1, max: 10), optional
       end
     end
 
@@ -130,6 +131,16 @@ describe "Coercive" do
 
         assert_coercion_error(expected_errors) { @coercion.call("foo" => value) }
       end
+    end
+
+    it "errors if the input is out of bounds" do
+      expected_errors = { "baz" => "too_small" }
+
+      assert_coercion_error(expected_errors) { @coercion.call("baz" => 0) }
+      
+      expected_errors = { "baz" => "too_large" }
+
+      assert_coercion_error(expected_errors) { @coercion.call("baz" => 11) }
     end
   end
 


### PR DESCRIPTION
I recently thought of a use case where I saw a form that had a "number of testers" input that shouldn't be negative, so this could come in handy.

Any thoughts about adding `min` and `max` to `float`? I couldn't think of a concrete use case, but there may be some out there.