### PR TITLE
Add min and max options to float coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,19 +202,26 @@ CoerceFoo.call("foo_bounds" => 11)
 # => Coercive::Error: {"foo_bounds"=>"too_high"}
 ```
 
-### `float`
+### `float(min:, max:)`
 
-`float` expects, well, a float value.
+`float` expects, well, a float value. It supports optional `min` and `max` options to check if the user input is within certain bounds.
 
 ```ruby
 module CoerceFoo
   extend Coercive
 
-  attribute :foo, float, optional
+  attribute :foo,        float,                     optional
+  attribute :foo_bounds, float(min: 1.0, max: 5.5), optional
 end
 
 CoerceFoo.call("foo" => "bar")
 # => Coercive::Error: {"foo"=>"not_valid"}
+
+CoerceFoo.call("foo" => "0.5")
+# => Coercive::Error: {"foo"=>"too_low"}
+
+CoerceFoo.call("foo" => 6.5)
+# => Coercive::Error: {"foo"=>"too_high"}
 
 CoerceFoo.call("foo" => "0.1")
 # => {"foo"=>0.1}

--- a/lib/coercive.rb
+++ b/lib/coercive.rb
@@ -171,13 +171,18 @@ module Coercive
 
   # Public DSL: Return a coerce function to coerce input to a Float.
   # Used when declaring an attribute. See documentation for attr_coerce_fns.
-  def float
+  def float(min: nil, max: nil)
     ->(input) do
-      begin
-        Float(input)
-      rescue TypeError, ArgumentError
-        fail Coercive::Error.new("not_numeric")
-      end
+      input = begin
+                Float(input)
+              rescue TypeError, ArgumentError
+                fail Coercive::Error.new("not_numeric")
+              end
+
+      fail Coercive::Error.new("too_low")  if min && input < min
+      fail Coercive::Error.new("too_high") if max && input > max
+
+      input
     end
   end
 

--- a/test/coercive.rb
+++ b/test/coercive.rb
@@ -149,7 +149,8 @@ describe "Coercive" do
       @coercion = Module.new do
         extend Coercive
 
-        attribute :foo, float, required
+        attribute :foo, float,                     optional
+        attribute :bar, float(min: 1.0, max: 5.5), optional
       end
     end
 
@@ -175,6 +176,16 @@ describe "Coercive" do
 
         assert_coercion_error(expected_errors) { @coercion.call("foo" => bad) }
       end
+    end
+
+    it "errors if the input is out of bounds" do
+      expected_errors = { "bar" => "too_low" }
+
+      assert_coercion_error(expected_errors) { @coercion.call("bar" => 0.5) }
+      
+      expected_errors = { "bar" => "too_high" }
+
+      assert_coercion_error(expected_errors) { @coercion.call("bar" => 6.0) }
     end
   end
 


### PR DESCRIPTION
As discussed in #6, here's the follow up implementation of `min` and `max` for `float`